### PR TITLE
Add a Spring Boot starter

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -103,3 +103,20 @@ editor:
     - "group": "org.projectlombok"
     - "artifact": "lombok"
 
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170728065612"
+editor:
+  name: "StarterAdditionEditor"
+  group: "atomist"
+  artifact: "spring-team-handlers"
+  version: "0.7.8"
+  origin:
+    repo: "git@github.com:atomisthq/spring-team-handlers.git"
+    branch: "1e5401f1adbf17b3401d491f2b8d50a41d637c73"
+    sha: "1e5401f"
+  parameters:
+    - "group": "org.springframework.boot"
+    - "artifact": "spring-boot-starter-thymeleaf"
+

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
 
 
 
+
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-thymeleaf</artifactId>
+</dependency>
 </dependencies>
 
 	<build>


### PR DESCRIPTION
Created by Atomist Editor `StarterAdditionEditor`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170728065612"
editor:
  name: "StarterAdditionEditor"
  group: "atomist"
  artifact: "spring-team-handlers"
  version: "0.7.8"
  origin:
    repo: "git@github.com:atomisthq/spring-team-handlers.git"
    branch: "1e5401f1adbf17b3401d491f2b8d50a41d637c73"
    sha: "1e5401f"
  parameters:
    - "group": "org.springframework.boot"
    - "artifact": "spring-boot-starter-thymeleaf"

```